### PR TITLE
feat(cue): require CUE language version v0.17

### DIFF
--- a/.github/workflows/branch-publish.yml
+++ b/.github/workflows/branch-publish.yml
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 env:
-  CUE_VERSION: 'v0.16.0'
+  CUE_VERSION: 'v0.17.0-alpha.1'
   # opmodel.dev modules publish to GHCR; everything else from registry.cue.works.
   CUE_REGISTRY: 'opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup CUE
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
         with:
-          version: v0.16.0
+          version: v0.17.0-alpha.1
 
       - name: Install Task
         uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 # v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  CUE_VERSION: 'v0.16.0'
+  CUE_VERSION: 'v0.17.0-alpha.1'
   # opmodel.dev modules publish to GHCR; everything else from registry.cue.works.
   CUE_REGISTRY: 'opmodel.dev=ghcr.io/open-platform-model,registry.cue.works'
 

--- a/src/cue.mod/module.cue
+++ b/src/cue.mod/module.cue
@@ -1,6 +1,6 @@
 module: "opmodel.dev/core@v0"
 language: {
-	version: "v0.16.0"
+	version: "v0.17.0"
 }
 source: {
 	kind: "self"


### PR DESCRIPTION
Bump the module's declared language version from v0.16.0 to v0.17.0 to match the upgraded CUE toolchain. Schema definitions are unchanged; this raises the minimum CUE version consumers need to evaluate the module.

Spec-Impact: none (language version pin only; no schema construct changed)