### PR TITLE
feat(module): make #Module identity author-supplied (fix self-cycle re-admission)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -249,8 +249,8 @@ A Module is the unit of versioning and distribution. A published Module at `exam
 
     metadata: {
         name!:       #NameType
-        modulePath:  metadata.modulePath                                  // bound by the enclosing cue.mod
-        version:     metadata.version                                     // bound by the enclosing cue.mod
+        modulePath!: #ModulePathType                                      // author-supplied in module.cue
+        version!:    #VersionType                                         // author-supplied in module.cue
         fqn:         #ModuleFQNType & "\(modulePath)/\(name):\(version)"  // semver-with-colon
         uuid:        #UUIDType & cue_uuid.SHA1(OPMNamespace, fqn)
 
@@ -286,7 +286,7 @@ Implementation: [`module.cue`](src/module.cue).
 
 - `kind` MUST be the literal string `"Module"`.
 - `metadata.name` MUST be kebab-case (`#NameType`).
-- `metadata.modulePath` and `metadata.version` MUST come from the enclosing CUE module identity (`cue.mod/module.cue`). Consumers MUST NOT override them in-file.
+- `metadata.modulePath` (`#ModulePathType`) and `metadata.version` (`#VersionType`) are author-supplied: a Module MUST declare them in its own `module.cue`, the same way `#Resource`, `#Trait`, `#Blueprint`, and `#Catalog` declare their identity. Both are required (`!`); a `#Module` value missing either is incomplete and cannot compute `fqn`/`uuid`.
 - `metadata.fqn` uses semver-with-colon (`modulePath/name:version`), distinct from `#Resource`'s `@v0` major-version separator. Consumers MUST NOT supply `fqn` directly.
 - `metadata.uuid` is computed as `SHA1(OPMNamespace, fqn)`. It is deterministic and stable across evaluations.
 - `#components` is required but MAY be empty for a Module that ships only as a configuration shape. Keys MUST satisfy `#NameType`.
@@ -299,6 +299,7 @@ Implementation: [`module.cue`](src/module.cue).
 
 #### Rationale
 
+- **Why `modulePath` / `version` are author-supplied typed-required fields, not self-referential.** Earlier revisions declared them `modulePath: metadata.modulePath` / `version: metadata.version` — a bare-direct self-cycle that resolves to itself, contributing neither a value nor a constraint. CUE never registers a cycle-only field as a permitted member of the *closed* `#Module`, so re-unifying an already-closed published `#Module` into `#ModuleRelease.#module` (the authored-`release.cue` import path) rejected the concrete `modulePath`/`version` as "field not allowed." The bug was invisible to `cue vet` because a standalone Module is only closed once. Declaring them `!: #ModulePathType` / `!: #VersionType` — the form every sibling identity-bearing construct already uses — makes them genuine permitted fields, fixes the re-unification, and adds real format validation the self-cycle silently skipped.
 - **Why `fqn` uses semver-with-colon while `#Resource` uses `@vN`.** Modules ship at specific versions (`1.2.3`); the consumer pins an exact release and migrates deliberately. Resources version on the contract surface (`v1`, `v2`); the consumer pins a contract major and treats patches as the publisher's concern. Different identity granularity, different separator — the visual distinction prevents confusion when both appear in a config tree.
 - **Why `uuid` is computed via `SHA1(OPMNamespace, fqn)` rather than authored or random.** Per Principle III (Determinism), two evaluations of the same `fqn` MUST yield the same identity. A registry, controller, or cluster can dedupe modules by uuid without coordinating an ID allocator. The schema fixture harness in `library/` pins a known uuid as a drift sentinel for the algorithm itself.
 - **Why `#config` is bare `_` and not a typed schema.** The configuration shape is per-module — every module's contract is different. Constraining `#config` at the core layer would either force a one-size-fits-all schema (too narrow) or accept everything (no value). The OpenAPI-v3 constraint is enforced by the downstream renderer, which has the context to apply it cleanly.

--- a/src/module.cue
+++ b/src/module.cue
@@ -11,9 +11,9 @@ import (
 	metadata: {
 		name!: #NameType // Example: "example-module"
 
-		modulePath: metadata.modulePath                                 // Example: "example.com/modules"
-		version:    metadata.version                                    // Example: "0.1.0"
-		fqn:        #ModuleFQNType & "\(modulePath)/\(name):\(version)" // Example: "example.com/modules/example-module:0.1.0"
+		modulePath!: #ModulePathType                                     // Example: "example.com/modules" (author-supplied in module.cue)
+		version!:    #VersionType                                        // Example: "0.1.0" (author-supplied in module.cue)
+		fqn:         #ModuleFQNType & "\(modulePath)/\(name):\(version)" // Example: "example.com/modules/example-module:0.1.0"
 
 		// Unique identifier for the module, computed as a UUID v5 (SHA1) of the FQN using the OPM namespace UUID.
 		uuid: #UUIDType & cue_uuid.SHA1(OPMNamespace, fqn)


### PR DESCRIPTION
## What

`#Module.metadata.modulePath`/`version` were declared self-referentially
(`modulePath: metadata.modulePath`) — a no-op cycle CUE never registers as a
permitted field of the closed `#Module`. Re-unifying a published, closed
`#Module` into `#ModuleRelease.#module` (the authored `release.cue` / operator
Release CR render path) rejected the concrete identity as **`field not allowed`**.
The Go-synthesized `ModuleRelease` path worked only via `synth.Release`'s
`cue.Scope` workaround.

This change declares the fields as **author-supplied typed-required identity**
(`modulePath!: #ModulePathType` / `version!: #VersionType`), matching `#Resource`,
`#Trait`, `#Blueprint` and `#Catalog` — `#Module` was the lone outlier.

## Why a minor

Tightens a published constraint on `#Module` (additive/identity-shape change),
so it rides a `feat:` → minor `0.5.0` under the repo's pre-1.0 policy. It is
behavior-preserving for every existing module — all already supply concrete,
regex-valid `modulePath`/`version` in their `module.cue`.

## Verification

- Reproduced the `field not allowed` re-admission failure (isolated + against
  real published artifacts); the fix clears it.
- Verified clean on CUE `v0.16.0` and `v0.17.0-alpha.1` through `alpha.3`.
- `task check` (fmt, vet, INDEX, SPEC inventory) green.
- `SPEC.md` §3.2 co-updated (Shape, Constraints, Rationale) — satisfies the
  co-update gate.

## Context

Fixes the Release-vs-ModuleRelease render divergence documented in
`opm-operator/docs/design/release-vs-modulerelease-render-divergence.md`. A
companion operator change rewrites the `releases/hello` fixture + adds a
KernelReleaseRenderer integration regression test.