### PR TITLE
feat(module): add derived nameSnakeCase to #Module.metadata

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -248,11 +248,12 @@ A Module is the unit of versioning and distribution. A published Module at `exam
     kind: "Module"
 
     metadata: {
-        name!:       #NameType
-        modulePath!: #ModulePathType                                      // author-supplied in module.cue
-        version!:    #VersionType                                         // author-supplied in module.cue
-        fqn:         #ModuleFQNType & "\(modulePath)/\(name):\(version)"  // semver-with-colon
-        uuid:        #UUIDType & cue_uuid.SHA1(OPMNamespace, fqn)
+        name!:          #NameType
+        nameSnakeCase:  #SnakeNameType & (#KebabToSnake & {"in": name}).out  // derived: hyphens → underscores
+        modulePath!:    #ModulePathType                                      // author-supplied in module.cue
+        version!:       #VersionType                                         // author-supplied in module.cue
+        fqn:            #ModuleFQNType & "\(modulePath)/\(name):\(version)"   // semver-with-colon
+        uuid:           #UUIDType & cue_uuid.SHA1(OPMNamespace, fqn)
 
         description?: string
         labels?:      #LabelsAnnotationsType
@@ -286,6 +287,7 @@ Implementation: [`module.cue`](src/module.cue).
 
 - `kind` MUST be the literal string `"Module"`.
 - `metadata.name` MUST be kebab-case (`#NameType`).
+- `metadata.nameSnakeCase` is the snake_case projection of `name` (`#KebabToSnake`: hyphens replaced with underscores) and MUST satisfy `#SnakeNameType`. It is derived — consumers MUST NOT supply it directly. It is intended as the CUE-identifier-safe form of the module name (canonical CUE package name and registry-path leaf under the module publishing convention).
 - `metadata.modulePath` (`#ModulePathType`) and `metadata.version` (`#VersionType`) are author-supplied: a Module MUST declare them in its own `module.cue`, the same way `#Resource`, `#Trait`, `#Blueprint`, and `#Catalog` declare their identity. Both are required (`!`); a `#Module` value missing either is incomplete and cannot compute `fqn`/`uuid`.
 - `metadata.fqn` uses semver-with-colon (`modulePath/name:version`), distinct from `#Resource`'s `@v0` major-version separator. Consumers MUST NOT supply `fqn` directly.
 - `metadata.uuid` is computed as `SHA1(OPMNamespace, fqn)`. It is deterministic and stable across evaluations.
@@ -300,6 +302,7 @@ Implementation: [`module.cue`](src/module.cue).
 #### Rationale
 
 - **Why `modulePath` / `version` are author-supplied typed-required fields, not self-referential.** Earlier revisions declared them `modulePath: metadata.modulePath` / `version: metadata.version` — a bare-direct self-cycle that resolves to itself, contributing neither a value nor a constraint. CUE never registers a cycle-only field as a permitted member of the *closed* `#Module`, so re-unifying an already-closed published `#Module` into `#ModuleRelease.#module` (the authored-`release.cue` import path) rejected the concrete `modulePath`/`version` as "field not allowed." The bug was invisible to `cue vet` because a standalone Module is only closed once. Declaring them `!: #ModulePathType` / `!: #VersionType` — the form every sibling identity-bearing construct already uses — makes them genuine permitted fields, fixes the re-unification, and adds real format validation the self-cycle silently skipped.
+- **Why `metadata.nameSnakeCase` exists as a derived field.** `#NameType` is kebab-case (RFC 1123 DNS-label), but a CUE package name and a CUE registry-path leaf must be valid CUE identifiers — which forbid hyphens. Authors therefore publish hyphenated-named modules under an underscored path/package (e.g. name `zot-registry-ttl` published at `…/zot_registry_ttl`), and the two forms drift. Deriving the snake_case form in the schema gives every consumer one authoritative, deterministic projection of the name into identifier space, rather than each re-implementing `strings.Replace(name, "-", "_")` and risking divergence. It is a *projection of name*, not an independent field, so it cannot disagree with `name`. The companion module publishing convention (see `enhancements/`) builds the canonical registry path on `modulePath/nameSnakeCase` so an imported module is resolvable from its metadata alone.
 - **Why `fqn` uses semver-with-colon while `#Resource` uses `@vN`.** Modules ship at specific versions (`1.2.3`); the consumer pins an exact release and migrates deliberately. Resources version on the contract surface (`v1`, `v2`); the consumer pins a contract major and treats patches as the publisher's concern. Different identity granularity, different separator — the visual distinction prevents confusion when both appear in a config tree.
 - **Why `uuid` is computed via `SHA1(OPMNamespace, fqn)` rather than authored or random.** Per Principle III (Determinism), two evaluations of the same `fqn` MUST yield the same identity. A registry, controller, or cluster can dedupe modules by uuid without coordinating an ID allocator. The schema fixture harness in `library/` pins a known uuid as a drift sentinel for the algorithm itself.
 - **Why `#config` is bare `_` and not a typed schema.** The configuration shape is per-module — every module's contract is different. Constraining `#config` at the core layer would either force a one-size-fits-all schema (too narrow) or accept everything (no value). The OpenAPI-v3 constraint is enforced by the downstream renderer, which has the context to apply it cleanly.

--- a/src/INDEX.md
+++ b/src/INDEX.md
@@ -58,11 +58,13 @@ CUE module: `opmodel.dev/core@v0`
 | `#FQNType` | `types.cue` | FQNType: primitive definition FQN — path/name@semver Example: "opmodel |
 | `#KebabToCamel` | `types.cue` | KebabToCamel converts a kebab-case string to camelCase |
 | `#KebabToPascal` | `types.cue` | KebabToPascal converts a kebab-case string to PascalCase |
+| `#KebabToSnake` | `types.cue` | KebabToSnake converts a kebab-case string to snake_case (hyphens → underscores) |
 | `#LabelsAnnotationsType` | `types.cue` |  |
 | `#MajorVersionType` | `types.cue` | MajorVersionType: major version prefix used in primitive FQNs Example: "v1", "v0" |
 | `#ModuleFQNType` | `types.cue` | ModuleFQNType: container-style FQN for #Module — path/name:semver Example: "opmodel |
 | `#ModulePathType` | `types.cue` | ModulePathType: plain registry path without embedded version Example: "opmodel |
 | `#NameType` | `types.cue` | NameType: RFC 1123 DNS label — lowercase alphanumeric with hyphens, max 63 chars |
+| `#SnakeNameType` | `types.cue` | SnakeNameType: snake_case projection of #NameType — lowercase alphanumeric with underscores |
 | `#UUIDType` | `types.cue` | UUIDType: RFC 4122 UUID in standard format (lowercase hex) |
 | `#VersionType` | `types.cue` | Semver 2 |
 

--- a/src/module.cue
+++ b/src/module.cue
@@ -11,6 +11,13 @@ import (
 	metadata: {
 		name!: #NameType // Example: "example-module"
 
+		// nameSnakeCase: snake_case projection of name (hyphens → underscores).
+		// A CUE-identifier-safe form of the module name (e.g. "zot-registry-ttl"
+		// → "zot_registry_ttl"), intended as the canonical CUE package name and
+		// registry-path leaf under the OPM module publishing convention. Derived
+		// from name — authors never set it.
+		nameSnakeCase: #SnakeNameType & (#KebabToSnake & {"in": name}).out
+
 		modulePath!: #ModulePathType                                     // Example: "example.com/modules" (author-supplied in module.cue)
 		version!:    #VersionType                                        // Example: "0.1.0" (author-supplied in module.cue)
 		fqn:         #ModuleFQNType & "\(modulePath)/\(name):\(version)" // Example: "example.com/modules/example-module:0.1.0"

--- a/src/types.cue
+++ b/src/types.cue
@@ -9,6 +9,12 @@ import (
 // NameType: RFC 1123 DNS label — lowercase alphanumeric with hyphens, max 63 chars
 #NameType: string & =~"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
 
+// SnakeNameType: snake_case projection of #NameType — lowercase alphanumeric
+// with underscores. Same character budget as #NameType; differs only in the
+// separator (`_` instead of `-`), making it a valid CUE identifier (and thus a
+// usable CUE package name / registry-path leaf).
+#SnakeNameType: string & =~"^[a-z0-9]([a-z0-9_]*[a-z0-9])?$" & strings.MinRunes(1) & strings.MaxRunes(63)
+
 // ModulePathType: plain registry path without embedded version
 // Example: "opmodel.dev/opm/modules", "opmodel.dev/opm/traits/workload"
 #ModulePathType: string & =~"^[a-z0-9.-]+(/[a-z0-9.-]+)*$" & strings.MinRunes(1) & strings.MaxRunes(254)
@@ -56,6 +62,13 @@ OPMNamespace: "11bc6112-a6e8-4021-bec9-b3ad246f9466"
 		let _runes = strings.Runes(p)
 		strings.ToUpper(strings.SliceRunes(p, 0, 1)) + strings.SliceRunes(p, 1, len(_runes))
 	}], "")
+}
+
+// KebabToSnake converts a kebab-case string to snake_case (hyphens → underscores).
+// Usage: (#KebabToSnake & {"in": "zot-registry-ttl"}).out => "zot_registry_ttl"
+#KebabToSnake: {
+	X="in": string
+	out:    strings.Replace(X, "-", "_", -1)
 }
 
 // KebabToCamel converts a kebab-case string to camelCase.


### PR DESCRIPTION
nameSnakeCase is the snake_case projection of metadata.name (via the new #KebabToSnake / #SnakeNameType helpers), giving consumers one deterministic, identifier-safe form of the module name to use as the canonical CUE package name and registry-path leaf. Anchors the module publishing convention (enhancements/0003).